### PR TITLE
Updating JobIDs with MongoDB ObjectIDs

### DIFF
--- a/backend/routes/api/expenseRoutes.js
+++ b/backend/routes/api/expenseRoutes.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const ExpenseModel = require("../../models/expense");
 const { computeUserShares } = require("../../utils/costSplitter");
 const { postToSplitwise } = require("../../services/splitwiseService");
+const mongoose = require("mongoose");
 
 router.get("/get-expenses/:groupId", async (req, res) => {
   const { groupId } = req.params;
@@ -192,7 +193,7 @@ router.post("/add-manual-expense", async (req, res) => {
     const userName = req?.user?.user_details?.user?.first_name;
 
     const description = "Custom Expense to Group";
-    const jobId = "custom";
+    const jobId = new mongoose.Types.ObjectId().toString();
 
     const groupMembers = group.members.map((m) => m.id.toString());
 


### PR DESCRIPTION
This pull request introduces a small but important improvement to the way manual expenses are tracked in the backend. The main change is the use of a unique identifier for each manual expense, which enhances traceability and prevents potential ID collisions.

Expense tracking improvements:

* Changed the assignment of `jobId` in the `/add-manual-expense` route to generate a unique ObjectId using `mongoose.Types.ObjectId().toString()`, instead of using a static string. This ensures each manual expense has a unique identifier.
* Added the `mongoose` library import to `expenseRoutes.js` to support ObjectId generation.